### PR TITLE
set default perl executable to $^X

### DIFF
--- a/lib/Test/AnyEvent/plackup.pm
+++ b/lib/Test/AnyEvent/plackup.pm
@@ -50,7 +50,7 @@ sub _perl {
     $plackup_lib_dir_name =~ s{[/\\]Test[/\\]AnyEvent[/\\]plackup\.pm$}{};
     push @$perl_inc, $plackup_lib_dir_name;
     return (
-        defined $perl ? $perl : 'perl',
+        defined $perl ? $perl : $^X,
         (map { "-I$_" } @$perl_inc),
         @{$self->perl_options},
     );

--- a/t/test-anyevent-plackup.t
+++ b/t/test-anyevent-plackup.t
@@ -13,7 +13,7 @@ test {
 
     my $server = Test::AnyEvent::plackup->new;
     is_deeply $server->get_command, [
-        'perl',
+        $^X,
         '-I' . file(__FILE__)->dir->parent->subdir('lib'),
         do { my $v = `which plackup` || 'plackup'; chomp $v; $v },
         '--port' => $server->port,
@@ -31,7 +31,7 @@ test {
     $server->port(1244);
     $server->server('Twiggy');
     is_deeply $server->get_command, [
-        'perl',
+        $^X,
         '-I' . file(__FILE__)->dir->parent->subdir('lib'),
         'hoge/plackup',
         '--app' => 'path/to/app.psgi',
@@ -63,7 +63,7 @@ test {
     my $server = Test::AnyEvent::plackup->new;
     $server->perl_inc(['path1', 'path2']);
     is_deeply $server->get_command, [
-        'perl',
+        $^X,
         '-Ipath1', '-Ipath2',
         '-I' . file(__FILE__)->dir->parent->subdir('lib'),
         do { my $v = `which plackup` || 'plackup'; chomp $v; $v },


### PR DESCRIPTION
On some circumstance where `perl` executable not living in `PATH` is used, invoking Perl using `$^X` would be suitable.
